### PR TITLE
Remove external reader option

### DIFF
--- a/Valyreon.Elib.Wpf/Models/ApplicationData.cs
+++ b/Valyreon.Elib.Wpf/Models/ApplicationData.cs
@@ -65,15 +65,9 @@ namespace Valyreon.Elib.Wpf.Models
     {
         public bool AutomaticallyImportWithFoundISBN { get; set; }
         public bool AutomaticallyImportBooksWithValidData { get; set; }
-        public string ExternalReaderPath { get; set; }
         public List<string> Formats { get; set; } = new List<string> { ".epub", ".mobi" };
         public string LibraryFolder { get; set; }
         public bool RememberFilterInNextView { get; set; }
         public bool ScanAtStartup { get; set; } = true;
-
-        public bool IsExternalReaderSpecifiedAndValid()
-        {
-            return !string.IsNullOrWhiteSpace(ExternalReaderPath) && File.Exists(ExternalReaderPath);
-        }
     }
 }

--- a/Valyreon.Elib.Wpf/ViewModels/Controls/ApplicationSettingsViewModel.cs
+++ b/Valyreon.Elib.Wpf/ViewModels/Controls/ApplicationSettingsViewModel.cs
@@ -23,7 +23,6 @@ namespace Valyreon.Elib.Wpf.ViewModels.Controls
         private readonly IUnitOfWorkFactory uowFactory;
         private bool automaticallyImportWithFoundISBN;
         private string caption = "Settings";
-        private string externalReaderPath;
         private string libraryPath;
         private bool scanAtStartup;
 
@@ -34,7 +33,6 @@ namespace Valyreon.Elib.Wpf.ViewModels.Controls
             LibraryPath = properties.LibraryFolder;
             ScanAtStartup = properties.ScanAtStartup;
             Formats = new(properties.Formats);
-            ExternalReaderPath = properties.ExternalReaderPath;
             AutomaticallyImportWithFoundISBN = properties.AutomaticallyImportWithFoundISBN;
             this.properties = properties;
             this.uowFactory = uowFactory;
@@ -58,17 +56,7 @@ namespace Valyreon.Elib.Wpf.ViewModels.Controls
             set => Set(() => Caption, ref caption, value);
         }
 
-        public ICommand ChooseExternalReaderCommand => new RelayCommand(HandleChooseExternalReader);
         public ICommand ChooseLibraryCommand => new RelayCommand(HandleChooseLibrary);
-
-        public ICommand ClearExternalReaderCommand => new RelayCommand(() => ExternalReaderPath = null);
-
-        public string ExternalReaderPath
-        {
-            get => externalReaderPath;
-            set => Set(() => ExternalReaderPath, ref externalReaderPath, value);
-        }
-
         public ObservableCollection<string> Formats { get; set; }
         public string LibraryPath { get => libraryPath; set => Set(() => LibraryPath, ref libraryPath, value); }
         public ICommand RemoveFormatCommand => new RelayCommand(() => Formats.Remove(SelectedFormat));
@@ -114,24 +102,6 @@ namespace Valyreon.Elib.Wpf.ViewModels.Controls
             });
 
             MessengerInstance.Send(new ShowDialogMessage(dialogViewModel));
-        }
-
-        private void HandleChooseExternalReader()
-        {
-            using var dlg = new System.Windows.Forms.OpenFileDialog
-            {
-                CheckFileExists = true,
-                CheckPathExists = true,
-                FilterIndex = 0,
-                Multiselect = false,
-                InitialDirectory = Environment.ExpandEnvironmentVariables("%ProgramW6432%")
-            };
-
-            var result = dlg.ShowDialog();
-            if (result == System.Windows.Forms.DialogResult.OK && dlg.FileName != null)
-            {
-                ExternalReaderPath = dlg.FileName;
-            }
         }
 
         private void HandleChooseLibrary()
@@ -184,7 +154,6 @@ namespace Valyreon.Elib.Wpf.ViewModels.Controls
             properties.LibraryFolder = LibraryPath;
             properties.Formats = Formats.ToList();
             properties.AutomaticallyImportWithFoundISBN = AutomaticallyImportWithFoundISBN;
-            properties.ExternalReaderPath = ExternalReaderPath;
         }
     }
 }

--- a/Valyreon.Elib.Wpf/ViewModels/Controls/BookTileViewModel.cs
+++ b/Valyreon.Elib.Wpf/ViewModels/Controls/BookTileViewModel.cs
@@ -20,7 +20,6 @@ namespace Valyreon.Elib.Wpf.ViewModels.Controls
         private readonly LinkedListNode<Book> node;
         private readonly Selector selector;
         private readonly IUnitOfWorkFactory uowFactory;
-        private bool isExternalReaderSpecified;
 
         public BookTileViewModel(LinkedListNode<Book> bookNode, Selector selector, ApplicationProperties applicationProperties, IUnitOfWorkFactory uowFactory)
         {

--- a/Valyreon.Elib.Wpf/ViewModels/Controls/BookTileViewModel.cs
+++ b/Valyreon.Elib.Wpf/ViewModels/Controls/BookTileViewModel.cs
@@ -28,9 +28,6 @@ namespace Valyreon.Elib.Wpf.ViewModels.Controls
             this.selector = selector;
             ApplicationProperties = applicationProperties;
             this.uowFactory = uowFactory;
-            IsExternalReaderSpecified = applicationProperties.IsExternalReaderSpecifiedAndValid();
-
-            MessengerInstance.Register<AppSettingsChangedMessage>(this, _ => IsExternalReaderSpecified = applicationProperties.IsExternalReaderSpecifiedAndValid());
         }
 
         public ICommand AddToCollectionCommand => new RelayCommand(HandleAddToCollection);
@@ -46,7 +43,6 @@ namespace Valyreon.Elib.Wpf.ViewModels.Controls
         public ICommand GoToSeries =>
             new RelayCommand(() => Messenger.Default.Send(new SeriesSelectedMessage(Book.Series)));
 
-        public bool IsExternalReaderSpecified { get => isExternalReaderSpecified; set => Set(() => IsExternalReaderSpecified, ref isExternalReaderSpecified, value); }
         public ICommand OpenFileLocationCommand => new RelayCommand(OpenFileLocation);
         public ICommand OpenInReaderCommand => new RelayCommand(HandleOpenInReader);
         public ICommand ReadMarkCommand => new RelayCommand(HandleMarkRead);
@@ -160,10 +156,14 @@ namespace Valyreon.Elib.Wpf.ViewModels.Controls
 
         private void HandleOpenInReader()
         {
-            if (ApplicationProperties.IsExternalReaderSpecifiedAndValid())
+            var psi = new ProcessStartInfo
             {
-                Process.Start(ApplicationProperties.ExternalReaderPath, $@"""{Book.Path}""");
-            }
+                FileName = $@"""{Book.Path}""",
+                // UseShellExecute set to true in order to use ShellExecute instead of the default CreateProcess to open a file.
+                UseShellExecute = true
+            };
+
+            Process.Start(psi);
         }
 
         private async void HandleRemove()

--- a/Valyreon.Elib.Wpf/ViewModels/Flyouts/BookDetailsViewModel.cs
+++ b/Valyreon.Elib.Wpf/ViewModels/Flyouts/BookDetailsViewModel.cs
@@ -27,7 +27,6 @@ namespace Valyreon.Elib.Wpf.ViewModels.Flyouts
         private bool canGoNext;
         private bool canGoPrevious;
         private ObservableCollection<ObservableEntity> collectionSuggestions;
-        private bool isExternalReaderSpecified;
 
         public BookDetailsViewModel(LinkedListNode<Book> node, ApplicationProperties properties, IUnitOfWorkFactory uowFactory)
         {
@@ -35,9 +34,7 @@ namespace Valyreon.Elib.Wpf.ViewModels.Flyouts
             Book = node.Value;
             Properties = properties;
             this.uowFactory = uowFactory;
-            IsExternalReaderSpecified = Properties.IsExternalReaderSpecifiedAndValid();
             UpdateNavigationState();
-            MessengerInstance.Register<AppSettingsChangedMessage>(this, _ => IsExternalReaderSpecified = Properties.IsExternalReaderSpecifiedAndValid());
             MessengerInstance.Register<KeyPressedMessage>(this, HandleKeyMessage);
         }
 
@@ -115,8 +112,6 @@ namespace Valyreon.Elib.Wpf.ViewModels.Flyouts
                 });
             }
         }
-
-        public bool IsExternalReaderSpecified { get => isExternalReaderSpecified; set => Set(() => IsExternalReaderSpecified, ref isExternalReaderSpecified, value); }
 
         public ICommand NextBookCommand => new RelayCommand(HandleNextBook);
 
@@ -232,10 +227,14 @@ namespace Valyreon.Elib.Wpf.ViewModels.Flyouts
 
         private void HandleOpenBook()
         {
-            if (Properties.IsExternalReaderSpecifiedAndValid())
+            var psi = new ProcessStartInfo
             {
-                Process.Start(Properties.ExternalReaderPath, $@"""{Book.Path}""");
-            }
+                FileName = $@"""{Book.Path}""",
+                // UseShellExecute set to true in order to use ShellExecute instead of the default CreateProcess to open a file.
+                UseShellExecute = true
+            };
+
+            Process.Start(psi);
         }
 
         private async void HandlePreviousBook()

--- a/Valyreon.Elib.Wpf/Views/Controls/ApplicationSettingsControl.xaml
+++ b/Valyreon.Elib.Wpf/Views/Controls/ApplicationSettingsControl.xaml
@@ -111,44 +111,6 @@
                     </CheckBox>
                 </StackPanel>
             </Grid>
-            <Grid
-                Grid.Row="4"
-                Grid.Column="1"
-                Margin="0,15,0,15">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition />
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="5" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-
-                <TextBlock
-                    Margin="0,0,5,0"
-                    VerticalAlignment="Center"
-                    FontSize="13">
-                    External reader:
-                </TextBlock>
-                <c:ElibTextBox
-                    Grid.Column="1"
-                    Margin="0,0,5,0"
-                    VerticalContentAlignment="Center"
-                    IsEnabled="False"
-                    Placeholder="Not defined"
-                    Text="{Binding ExternalReaderPath}" />
-                <Button
-                    Grid.Column="2"
-                    Width="120"
-                    Command="{Binding ChooseExternalReaderCommand}">
-                    FIND
-                </Button>
-                <Button
-                    Grid.Column="4"
-                    Width="120"
-                    Command="{Binding ClearExternalReaderCommand}">
-                    CLEAR
-                </Button>
-            </Grid>
         </StackPanel>
     </Border>
 </UserControl>


### PR DESCRIPTION
- External reader option removed from settings.
    - The books will now be open in a system default program (reader).
 - If the default reader for the specific book format cannot be found, the system will prompt the user to select the adequate reader from the system.